### PR TITLE
listing 12-09: fix method name

### DIFF
--- a/rustbook-en/listings/ch12-an-io-project/listing-12-09/src/main.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-09/src/main.rs
@@ -22,7 +22,7 @@ struct Config {
 
 // ANCHOR: here
 impl Config {
-    fn build(args: &[String]) -> Result<Config, &'static str> {
+    fn new(args: &[String]) -> Result<Config, &'static str> {
         if args.len() < 3 {
             return Err("not enough arguments");
         }

--- a/rustbook-en/listings/ch12-an-io-project/listing-12-10/src/main.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-10/src/main.rs
@@ -29,7 +29,7 @@ struct Config {
 }
 
 impl Config {
-    fn build(args: &[String]) -> Result<Config, &'static str> {
+    fn new(args: &[String]) -> Result<Config, &'static str> {
         if args.len() < 3 {
             return Err("not enough arguments");
         }

--- a/rustbook-en/listings/ch12-an-io-project/listing-12-13/src/lib.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-13/src/lib.rs
@@ -8,7 +8,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn build(args: &[String]) -> Result<Config, &'static str> {
+    pub fn new(args: &[String]) -> Result<Config, &'static str> {
         // --snip--
         // ANCHOR_END: here
         if args.len() < 3 {

--- a/rustbook-en/listings/ch12-an-io-project/listing-12-13/src/main.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-13/src/main.rs
@@ -4,7 +4,7 @@ use std::process;
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    let config = Config::build(&args).unwrap_or_else(|err| {
+    let config = Config::new(&args).unwrap_or_else(|err| {
         println!("Problem parsing arguments: {err}");
         process::exit(1);
     });

--- a/rustbook-en/listings/ch12-an-io-project/listing-12-23/src/lib.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-23/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Config {
 
 // ANCHOR: here
 impl Config {
-    pub fn build(args: &[String]) -> Result<Config, &'static str> {
+    pub fn new(args: &[String]) -> Result<Config, &'static str> {
         if args.len() < 3 {
             return Err("not enough arguments");
         }

--- a/rustbook-en/listings/ch12-an-io-project/listing-12-23/src/main.rs
+++ b/rustbook-en/listings/ch12-an-io-project/listing-12-23/src/main.rs
@@ -6,7 +6,7 @@ use minigrep::Config;
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    let config = Config::build(&args).unwrap_or_else(|err| {
+    let config = Config::new(&args).unwrap_or_else(|err| {
         println!("Problem parsing arguments: {err}");
         process::exit(1);
     });


### PR DESCRIPTION
Исправил название функции в разделе [Возвращение Result из new вместо вызова panic!](https://doc.rust-lang.ru/book/ch12-03-improving-error-handling-and-modularity.html#%D0%92%D0%BE%D0%B7%D0%B2%D1%80%D0%B0%D1%89%D0%B5%D0%BD%D0%B8%D0%B5-result-%D0%B8%D0%B7-new-%D0%B2%D0%BC%D0%B5%D1%81%D1%82%D0%BE-%D0%B2%D1%8B%D0%B7%D0%BE%D0%B2%D0%B0-panic)