### PR TITLE
Исправление неправильной ссылки на листинг

### DIFF
--- a/rustbook-ru/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/rustbook-ru/src/ch09-03-to-panic-or-not-to-panic.md
@@ -60,7 +60,7 @@ experimentation purposes, but don't want to include it for rustdoc testing
 purposes. -->
 
 ```rust
-{{#include ../listings/ch09-error-handling/listing-09-13/src/main.rs:here}}
+{{#include ../listings/ch09-error-handling/listing-09-13/src/lib.rs:here}}
 ```
 
 <span class="caption">Листинг 9-13. Тип <code>Guess</code>, который будет создавать экземпляры только для значений от 1 до 100</span>


### PR DESCRIPTION
Перепутана ссылка на листинг кода 
https://doc.rust-lang.ru/book/ch09-03-to-panic-or-not-to-panic.html
![изображение](https://github.com/user-attachments/assets/3473a8bc-35a0-4f62-a116-296f05cef532)

